### PR TITLE
ヘッダータイトルを中央揃えに修正

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -54,9 +54,13 @@ export default function HomeScreen() {
           { backgroundColor: Colors[colorScheme].background },
         ]}
       >
-        <Text style={[styles.headerTitle, { color: Colors[colorScheme].text }]}>
-          マイライブラリ
-        </Text>
+        <View style={styles.titleContainer}>
+          <Text
+            style={[styles.headerTitle, { color: Colors[colorScheme].text }]}
+          >
+            マイライブラリ
+          </Text>
+        </View>
         <TouchableOpacity
           style={[
             styles.addButton,
@@ -95,12 +99,21 @@ const styles = StyleSheet.create({
   },
   headerContainer: {
     flexDirection: "row",
-    justifyContent: "space-between",
+    justifyContent: "flex-end",
     alignItems: "center",
     paddingHorizontal: 16,
     paddingVertical: 10,
     borderBottomWidth: 1,
     borderBottomColor: "#E8E0D1", // Vintage Beige
+    position: "relative",
+  },
+  titleContainer: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    alignItems: "center",
+    justifyContent: "center",
+    zIndex: 1,
   },
   headerTitle: {
     fontSize: 18,

--- a/app/book/[id].tsx
+++ b/app/book/[id].tsx
@@ -130,7 +130,9 @@ export default function BookDetailScreen() {
         >
           <Ionicons name="arrow-back" size={24} color={textColor} />
         </TouchableOpacity>
-        <Text style={[styles.headerTitle, { color: textColor }]}>書籍</Text>
+        <View style={styles.titleContainer}>
+          <Text style={[styles.headerTitle, { color: textColor }]}>書籍</Text>
+        </View>
       </View>
 
       <ScrollView style={styles.scrollContainer}>
@@ -198,9 +200,18 @@ const styles = StyleSheet.create({
     padding: 16,
     borderBottomWidth: 1,
     borderBottomColor: "#ddd",
+    position: "relative",
   },
   backButton: {
     marginRight: 10,
+    zIndex: 1,
+  },
+  titleContainer: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    alignItems: "center",
+    justifyContent: "center",
   },
   headerTitle: {
     fontSize: 18,

--- a/app/book/add-clip.tsx
+++ b/app/book/add-clip.tsx
@@ -156,9 +156,11 @@ export default function AddClipScreen() {
         >
           <Ionicons name="arrow-back" size={24} color={textColor} />
         </TouchableOpacity>
-        <Text style={[styles.headerTitle, { color: textColor }]}>
-          クリップを追加
-        </Text>
+        <View style={styles.titleContainer}>
+          <Text style={[styles.headerTitle, { color: textColor }]}>
+            クリップを追加
+          </Text>
+        </View>
       </View>
 
       <ScrollView
@@ -310,9 +312,18 @@ const styles = StyleSheet.create({
     alignItems: "center",
     padding: 16,
     borderBottomWidth: 1,
+    position: "relative",
   },
   backButton: {
     marginRight: 10,
+    zIndex: 1,
+  },
+  titleContainer: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    alignItems: "center",
+    justifyContent: "center",
   },
   headerTitle: {
     fontSize: 18,

--- a/app/clip/[id].tsx
+++ b/app/clip/[id].tsx
@@ -168,9 +168,11 @@ export default function ClipDetailScreen() {
           >
             <Ionicons name="arrow-back" size={24} color={textColor} />
           </TouchableOpacity>
-          <Text style={[styles.headerTitle, { color: textColor }]}>
-            クリップを編集
-          </Text>
+          <View style={styles.titleContainer}>
+            <Text style={[styles.headerTitle, { color: textColor }]}>
+              クリップを編集
+            </Text>
+          </View>
         </View>
 
         <ScrollView style={styles.scrollContainer}>
@@ -273,9 +275,18 @@ const styles = StyleSheet.create({
     alignItems: "center",
     padding: 16,
     borderBottomWidth: 1,
+    position: "relative",
   },
   backButton: {
     marginRight: 10,
+    zIndex: 1,
+  },
+  titleContainer: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    alignItems: "center",
+    justifyContent: "center",
   },
   headerTitle: {
     fontSize: 18,

--- a/components/ImageSelectionView.tsx
+++ b/components/ImageSelectionView.tsx
@@ -167,27 +167,6 @@ export default function ImageSelectionView({
     },
   });
 
-  // 選択範囲のスタイルを計算
-  const _getSelectionStyle = () => {
-    if (!hasSelection && !isSelecting) return null;
-
-    const startX = Math.min(selectionStart.x, selectionEnd.x);
-    const startY = Math.min(selectionStart.y, selectionEnd.y);
-    const width = Math.abs(selectionEnd.x - selectionStart.x);
-    const height = Math.abs(selectionEnd.y - selectionStart.y);
-
-    return {
-      position: "absolute" as const,
-      left: startX,
-      top: startY,
-      width,
-      height,
-      borderWidth: 2,
-      borderColor: "#FF4757",
-      backgroundColor: "rgba(255, 71, 87, 0.1)",
-    };
-  };
-
   // 現在の選択範囲を計算
   const currentSelection = {
     x: Math.min(selectionStart.x, selectionEnd.x),


### PR DESCRIPTION
各画面のヘッダータイトルを左揃えから中央揃えに修正しました。\n\n- ホーム画面\n- 書籍詳細画面\n- クリップ詳細画面\n- クリップ追加画面